### PR TITLE
[Fix] Error exporting GNPSMGFFile with MS1 only files

### DIFF
--- a/04_GNPS_Export.ipynb
+++ b/04_GNPS_Export.ipynb
@@ -114,18 +114,7 @@
     "        new_map.push_back(f)\n",
     "\n",
     "Consensus_file= os.path.join(path ,'filtered' + \".consensusXML\")\n",
-    "ConsensusXMLFile().store(Consensus_file, new_map)\n",
-    "\n",
-    "input_mzml_files = glob.glob(os.path.join(\"results\", \"interim\", \"mzML\", \"MapAligned_*.mzML\"))\n",
-    "\n",
-    "mzML_files = []\n",
-    "for mzML in input_mzml_files:\n",
-    "    exp = MSExperiment()\n",
-    "    MzMLFile().load(mzML, exp)\n",
-    "    for spec in exp:\n",
-    "        if spec.getMSLevel() == 2:\n",
-    "            mzML_files.append(mzML)\n",
-    "            break"
+    "ConsensusXMLFile().store(Consensus_file, new_map)"
    ]
   },
   {
@@ -145,6 +134,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "mzML_files = glob.glob(os.path.join(\"results\", \"interim\", \"mzML\", \"MapAligned_*.mzML\"))\n",
+    "\n",
     "out_file = os.path.join(\"results\", \"GNPSexport\", \"MSMS.mgf\")\n",
     "spectra_clustering = GNPSMGFFile()\n",
     "spectra_clustering.store(Consensus_file.encode(), [s.encode() for s in mzML_files], out_file.encode())"

--- a/04_GNPS_Export.ipynb
+++ b/04_GNPS_Export.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,9 +47,93 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>filename</th>\n",
+       "      <th>ATTRIBUTE_MAPID</th>\n",
+       "      <th>ATTRIBUTE_genomeID</th>\n",
+       "      <th>ATTRIBUTE_media</th>\n",
+       "      <th>ATTRIBUTE_comment</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Blank.mzML</td>\n",
+       "      <td>MAP0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan_nan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Control.mzML</td>\n",
+       "      <td>MAP1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan_nan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Pool.mzML</td>\n",
+       "      <td>MAP2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan_nan</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Treatment.mzML</td>\n",
+       "      <td>MAP3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>nan_nan</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         filename ATTRIBUTE_MAPID ATTRIBUTE_genomeID ATTRIBUTE_media  \\\n",
+       "0      Blank.mzML            MAP0                NaN             NaN   \n",
+       "1    Control.mzML            MAP1                NaN             NaN   \n",
+       "2       Pool.mzML            MAP2                NaN             NaN   \n",
+       "3  Treatment.mzML            MAP3                NaN             NaN   \n",
+       "\n",
+       "  ATTRIBUTE_comment  \n",
+       "0           nan_nan  \n",
+       "1           nan_nan  \n",
+       "2           nan_nan  \n",
+       "3           nan_nan  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "path= os.path.join(\"results\", \"GNPSexport\")\n",
     "isExist= os.path.exists(path)\n",
@@ -93,7 +177,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "blub\n"
+     ]
+    }
+   ],
    "source": [
     "path= os.path.join(\"results\", \"interim\", \"GNPSexport\")\n",
     "isExist= os.path.exists(path)\n",
@@ -113,6 +205,9 @@
     "    if f.getPeptideIdentifications() !=[]:\n",
     "        new_map.push_back(f)\n",
     "\n",
+    "if new_map.empty():\n",
+    "    print(\"WARNING: No features with MS2 information. GNPSExport will output an empty file.\")\n",
+    "\n",
     "Consensus_file= os.path.join(path ,'filtered' + \".consensusXML\")\n",
     "ConsensusXMLFile().store(Consensus_file, new_map)"
    ]
@@ -130,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +276,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -196,11 +291,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.0"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "edde62aa2661007f0756e9790e7a328c288a583bf6ce768a355147dac67c8db8"
-   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
With OpenMS > 3.0 there were issues running GNPSExport with a bunch of MS1 only files together with MS1/MS2.

Previously we simply filtered the input mzML file list to contain only MS2 files. However, if there are MS1 only files in the consensus map the algorithm will try to find them in the mzML list, resulting in error.

To fix this simply passed all mzML files to the algorihm works perfectly.